### PR TITLE
Regexp fix for disqualified players

### DIFF
--- a/core/minippbuddy.class.php
+++ b/core/minippbuddy.class.php
@@ -29,6 +29,16 @@ class miniPPBuddy {
     private $players = array();
    
     /**
+     * Full player name string with all tags
+     * Stores alternative strings for names, nick [TAG] [TAG] breaks a bit
+     * of playlog also when it comes to fishes for player.
+     * Most likely due to player not using country and team name fields in game
+     * Array value points to stripped name in $players array key
+     * @var array
+     */
+    private $_playerAltNames = array();
+    
+    /**
      * @var int Amount of rounds to be parsed, zero equals to infinite rounds
      */
     private $rounds = 0;
@@ -135,6 +145,7 @@ class miniPPBuddy {
      * Remove odd characters for array keys
      * Characters include scandic ä, ö, å and so on
      * list can be adjusted when new issue arises, which will arise sooner than later
+     * @return string
      */
     public function strip($string) {
         return (string) strtolower(
@@ -260,6 +271,22 @@ class miniPPBuddy {
             return false;
         }
         return $this->players[$stripped];
+    }
+    
+    public function setAltPlayerName($altName, $name) {
+        $this->_playerAltNames[$this->strip($altName)] = $this->strip($name);
+    }
+    
+    public function getAltPlayerName($altName) {
+        $altName = $this->strip($altName);
+        if (array_key_exists($altName, $this->_playerAltNames)) {
+            return $this->_playerAltNames[$altName];
+        }
+        return false;
+    }
+    
+    public function getAltPlayerNames() {
+        return $this->_playerAltNames;
     }
     
     /**

--- a/core/player.class.php
+++ b/core/player.class.php
@@ -12,6 +12,12 @@ class miniPlayer {
     protected $_wasDisconnected = false;
     protected $_isDisqualified = false;
     
+    /**
+     * For those players who have nickname [tag] [tag]
+     * @var string|boolean
+     */
+    protected $_tags = false;
+    
     private $_parsingPlayer = false;
     
     public function __construct(miniPPBuddy &$buddy) {
@@ -124,6 +130,17 @@ class miniPlayer {
         $this->_isDisqualified = true;
     }
     
+    public function setTags($tags) {
+        $this->_tags = $tags;
+    }
+    
+    public function getTags() {
+        if ($this->_tags !== false) {
+            return $this->_tags;
+        }
+        return false;
+    }
+    
     public function debug() {
         print_r(array(
             'name' => $this->name,
@@ -131,7 +148,8 @@ class miniPlayer {
             'country' => $this->country,
             'scores' => $this->scores,
             'positions' => $this->positions,
-            'fishies' => $this->fishes
+            'fishies' => $this->fishes,
+            'tags' => $this->_tags
         ));
     }
     

--- a/core/player.class.php
+++ b/core/player.class.php
@@ -10,6 +10,7 @@ class miniPlayer {
     protected $scores = array();
     protected $fishes = array();
     protected $_wasDisconnected = false;
+    protected $_isDisqualified = false;
     
     private $_parsingPlayer = false;
     
@@ -117,6 +118,10 @@ class miniPlayer {
     
     public function setDisconnected() {
         $this->_wasDisconnected = true;
+    }
+    
+    public function setDisqualified() {
+        $this->_isDisqualified = true;
     }
     
     public function debug() {

--- a/core/regexp.class.php
+++ b/core/regexp.class.php
@@ -75,6 +75,15 @@ class miniRegexp {
      */
     const PLAYER_INFORMATION = '/(\*\d+|\d+)\.\s+(\[.*\]\s){0,1}(.+)\s+(\d+)\s+g/';
     
+    /** Player information including with the country tag after name, was too lazy to build too complex regexp for now
+     * 0 = whole line
+     * 1 = result position
+     * 2 = Team tag (could be empty '')
+     * 3 = Name with the country tag (if there is one)
+     * 4 = score
+     */
+    const PLAYER_INFORMATION_DISQ = '/(\*\d+|\d+)\.\s+(\[.*\]\s){0,1}(.+)\s+(\d+)\s+g \(disq\)/';
+    
     /** Player country
      * 0 = whole line
      * 1 = country code
@@ -137,6 +146,13 @@ class miniRegexp {
      * @var array
      */
     protected $_disconnectedPlayers = array();
+    
+    /**
+     * Holds disqualified players, this is to fix if player whose playlog is
+     * processed does not finish but playlog still shows "Omat kalat:"
+     * @var array
+     */
+    protected $_disqualifiedPlayers = array();
     
     /**
      * Playlog might containt multiple new rounds without aborting string
@@ -318,7 +334,7 @@ class miniRegexp {
         }
         return false;
     }
-    
+
     /**
      * Set disqualified player, no need for key as using array_search
      * @param string $name
@@ -343,12 +359,6 @@ class miniRegexp {
         }
     }
     
-    public function isDisqualified($row) {
-        if (preg_match(self::DISQUALIFIED, $row)) {
-            return true;
-        }
-        return false;
-    }
     /**
      * Reset _disconnectedPlayers array for new round
      */
@@ -356,13 +366,37 @@ class miniRegexp {
         $this->_disconnectedPlayers = array();
     }
     
-/*    public function isDisqualified($row) { MOST LIKELY TO BE REMOVED
+    public function isDisqualified($row) {
         if (preg_match(self::DISQUALIFIED, $row)) {
             return true;
         }
         return false;
     }
-*/    
+        
+    public function getDisqualifiedPlayerDetails($row) {
+        // NetBeans complains for uninitialized variables
+        $matches = null;
+        $country = null;
+        preg_match(self::PLAYER_INFORMATION_DISQ, $row, $matches);
+        preg_match(self::PLAYER_COUNTRY, $matches[3], $country);
+        if (isset($country[1])) {
+            //$matches[] = $country[1];
+            $matches[3] = trim(str_replace("[" . $country[1] . "]", '', $matches[3]));
+        } else {
+            //$matches[] = null;
+        }
+
+        return $matches;
+    }
+
+    public function setDisqualifiedPlayer($name) {
+        $this->_disqualifiedPlayers[] = $name;
+    }
+    
+    public function clearDisqualifiedPlayers() {
+        $this->_disqualifiedPlayers = array();
+    }
+
     public function isOwnFish($row) {
         if (strpos($row, self::SKIP_OWN) === 0) {
             return true;
@@ -412,7 +446,7 @@ class miniRegexp {
         $lake = null;
         $player = null;
         $rounds = $this->buddy->getRounds();
-        
+        $isDisqualified = false;
         foreach ($this->rows as $r) {
             if (!mb_detect_encoding($r, "UTF-8", true)) {
                 $r = utf8_encode($r);
@@ -447,14 +481,28 @@ class miniRegexp {
                     $lake->setBiggestPoints($this->buddy->getBiggestPoints($this->buddy->getRound()));
                     $this->setStage(self::IRRELEVANT);
                     $this->_parsingResults = true;
+                    
+                    $this->clearDisconnectedPlayers();
+                    $this->clearDisqualifiedPlayers();
                     break;
                 case $this->isFinished($r):
                     $this->setStage(self::RESULTS);
                     break;
-                case ($this->getStage() === self::RESULTS && $this->isDisqualified($r)):
-                    continue;
+/*                case ($this->getStage() === self::RESULTS && $this->isDisqualified($r)):
+                    continue;*/
                 case ($this->getStage() === self::RESULTS && $this->isResult($r)):
-                    if ($this->isDisconnected($r)) {
+                    if ($this->isDisqualified($r)) {
+                        $plr = $this->getDisqualifiedPlayerDetails($r);
+                        if ($lake->playerExists($plr[3])) {
+                            continue;
+                        }
+                        if (!$player = $this->buddy->getPlayer($plr[3])) {
+                            $player = $this->buddy->newPlayer($plr[3]);
+                        }
+                        $isDisqualified = true;
+                        $this->setDisqualifiedPlayer($plr[3], $player);
+                        $disqualified = true;
+                    } else if ($this->isDisconnected($r)) {
                         $plr = $this->getDisconnectedPlayerDetails($r);
                         if ($lake->playerExists($plr[3])) {
                             continue;
@@ -473,6 +521,7 @@ class miniRegexp {
                             $player = $this->buddy->newPlayer($plr[3]);
                         }
                         $disconnected = false;
+                        $disqualified = false;
                     }
                     $lake->setPlayer($player);
                     if ($disconnected === true) {
@@ -483,6 +532,7 @@ class miniRegexp {
                     $player->setTeam($plr[2]);
                     $player->setName($plr[3]);
                     $player->setScore($this->buddy->getRound(), $plr[4]);
+
                     if (isset($plr[5])) {
                         $player->setCountry($plr[5]);
                     }

--- a/core/regexp.class.php
+++ b/core/regexp.class.php
@@ -22,7 +22,7 @@ class miniRegexp {
     const NEW_ROUND_SELF = 'New LAN CLIENT';
     // Begin row processing after this row
     const FINISHED = 'Competition finished';
-    // Skip plenty of unnecessary rows through the file
+    // Identifies when to start processing fishes and attach first group into playlog owner
     const SKIP_OWN = 'Omat kalat:';
     // Joining players
     const JOIN = '-->';
@@ -105,7 +105,7 @@ class miniRegexp {
      * 3 = Total weight
      * 4 = Biggest
      */
-    const FISHES_FOR_PLAYER = '/([a-zA-ZäöåÄÖÅ\.]*)\s+[a-zA-ZäöåÄÖÅ\.]+:\s+(\d+)\s+[a-zA-Z]+:\s+(\d+)\s+\([a-zA-Z]+:\s(\d+)\s+g\)/';
+    const FISHES_FOR_PLAYER = '/([a-zA-ZäöåÄÖÅ\.]*)\s+[a-zA-ZäöåÄÖÅ\.\-0-9]+:\s+(\d+)\s+[a-zA-Z]+:\s+(\d+)\s+\([a-zA-Z]+:\s(\d+)\s+g\)/';
     
     /**
      * Biggest fish for the lake

--- a/core/request.class.php
+++ b/core/request.class.php
@@ -34,9 +34,8 @@ class miniRequest {
     public function sanitizePageQuery() {
         if (isset($_GET['q'])) {
             preg_match('/([a-zA-Z])/', $_GET['q'], $q);
-            print_r($q);
             if ($q) {
-                $_GET['q'] = filter_input('', 'q', '');
+                $_GET['q'] = filter_input(INPUT_GET, 'q');
             }
             
         }

--- a/processors/miniPlayerRanking.class.php
+++ b/processors/miniPlayerRanking.class.php
@@ -36,6 +36,7 @@ class miniPlayerRanking extends miniProcessor {
                 $this->addPlayerLakeResult($plrObj);
                 $this->addPlayerFishes($plrObj);
                 $this->addPlayerPoints($plrObj, $player['points']);
+                $this->addPlayerTags($plrObj);
                 $this->playedLake($plrObj);
             }
         }
@@ -155,6 +156,12 @@ class miniPlayerRanking extends miniProcessor {
         return array_key_exists($name, $this->_players);
     }
     
+    protected function addPlayerTags($plrObj) {
+        if ($plrObj->getTags()) {
+            $nameStripped = $this->_buddy->strip($plrObj->getName());
+            $this->_players[$nameStripped]['tags'] = $plrObj->getTags();
+        }
+    }
     /**
      * Initialises player structure to _teams['players'] array
      * @param miniPlayer $plrObj
@@ -175,7 +182,8 @@ class miniPlayerRanking extends miniProcessor {
             'lake_points' => array(),
             'lake_score' => array(),
             'biggest_points' => array(),
-            'fishes' => array()
+            'fishes' => array(),
+            'tags' => ''
         );
     }
     


### PR DESCRIPTION
Fix to regexp for disqualified players, otherwise worked fine but when playlog submitter was disqualified, "Omat kalat" is still shown but disqualified players was not saved before.